### PR TITLE
[RFR] Disable xdebug for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
 before_script:
     - cp var/jwt/private.pem.dist var/jwt/private.pem
     - cp var/jwt/public.pem.dist var/jwt/public.pem
+    - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
     - composer self-update
     - composer install --no-interaction
 


### PR DESCRIPTION
Travis starts with this composer message : `You are running composer with xdebug enabled. This has a major impact on runtime performance.`

In order to speed up tests, remove xdebug extension.
